### PR TITLE
set default route to `/bridge` on netlify deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/"
+  to = "/bridge"
+  status = 302


### PR DESCRIPTION
Resolves #78 