### PR TITLE
Make spinner inline with button text when pending

### DIFF
--- a/pages/bridge.tsx
+++ b/pages/bridge.tsx
@@ -236,11 +236,11 @@ const Bridge = () => {
                           : !bridgeToL1 || bridgeToL1IsLoading || !!bridgeToL1Error
                       }
                     >
-                      {(bridgeTarget === BridgeTarget.L2 && bridgeToL2IsLoading) ||
-                      (bridgeTarget === BridgeTarget.L1 && bridgeToL1IsLoading) ? (
-                        <Spinner />
-                      ) : (
-                        <span>Bridge to {target.chain.name}</span>
+                      Bridge to {target.chain.name}
+                      {(bridgeToL2IsLoading || bridgeToL1IsLoading) && (
+                        <span className="ml-2">
+                          <Spinner />
+                        </span>
                       )}
                     </button>
                   )


### PR DESCRIPTION
closes #93
l1 to l2:
<img width="612" alt="image" src="https://github.com/ScopeLift/l2-flexible-voting-frontend/assets/61768337/c799df1d-e053-4076-9eae-2849c1191002">
l2 to l1:
<img width="608" alt="image" src="https://github.com/ScopeLift/l2-flexible-voting-frontend/assets/61768337/3e8490d9-f2fe-484e-aa7c-162e9775fc49">


Seems like the only other place where the `Spinner` is used is `Bridge to <chain>` button. @wildmolasses Do we want to add a spinner and a loading state to other buttons, like the `delegate` button? And should I include those in this PR as well?