### PR TITLE
Prevent full-page reload on form submit and use `useEasyWrite`

### DIFF
--- a/hooks/useL2DelegateVote.ts
+++ b/hooks/useL2DelegateVote.ts
@@ -1,6 +1,6 @@
-import { usePrepareContractWrite, useContractWrite } from 'wagmi';
 import { parseAbi } from 'viem';
 import { useConfig } from '@/hooks/useConfig';
+import { useEasyWrite } from '@/hooks/useEasyWrite';
 
 type Props = {
   delegateAddress: `0x${string}`;
@@ -8,20 +8,19 @@ type Props = {
 
 export const useL2DelegateVote = ({ delegateAddress }: Props) => {
   const { l2 } = useConfig();
-  const { config, error: prepareError } = usePrepareContractWrite({
+
+  const { data, error, isLoading, write } = useEasyWrite({
     address: l2.tokenAddress,
     abi: parseAbi(['function delegate(address) public']),
     functionName: 'delegate',
     args: [delegateAddress],
     chainId: l2.chain.id,
   });
-  const { data, isLoading, isSuccess, error: writeError, write } = useContractWrite(config);
 
   return {
     data,
     isLoading,
-    isSuccess,
     write,
-    error: writeError || prepareError,
+    error,
   };
 };

--- a/pages/delegate.tsx
+++ b/pages/delegate.tsx
@@ -113,7 +113,13 @@ const Delegate: NextPage = () => {
                   has been proposed in order to be considered for that proposal.
                 </p>
               </div>
-              <form className="py-3" onSubmit={() => write!()}>
+              <form
+                className="py-3"
+                onSubmit={(event) => {
+                  event?.preventDefault();
+                  write!();
+                }}
+              >
                 <label className="block text-sm font-medium leading-6 text-gray-900">
                   Delegate Address
                 </label>


### PR DESCRIPTION
closes #86
closes #87
