### PR TITLE
Restyle delegate page

### DIFF
--- a/components/ProposalRow.tsx
+++ b/components/ProposalRow.tsx
@@ -252,8 +252,8 @@ export default function ProposalRow({
               </div>
             </div>
           ) : (
-            <div className="flex items-center justify-center p-5 bg-gray-100 h-32">
-              Proposal not bridged to L2
+            <div className="flex items-center justify-center p-5 ring-gray-200 rounded-lg h-32">
+              Proposal is not yet bridged to L2
             </div>
           )}
         </div>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.47.0",
+    "react-tooltip": "^5.23.0",
     "swr": "^2.2.4",
     "viem": "~1.10.7",
     "wagmi": "~1.4.1"

--- a/pages/[id]/delegate.tsx
+++ b/pages/[id]/delegate.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { useState } from 'react';
 import { ExclamationCircleIcon } from '@heroicons/react/20/solid';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
@@ -14,8 +15,10 @@ import { useL2CurrentVotingWeight } from '@/hooks/useCurrentVotingWeight';
 import { useL2DelegateVote } from '@/hooks/useL2DelegateVote';
 import { useL2Delegate } from '@/hooks/useL2Delegate';
 import { ZERO_ADDRESS } from '@/util/constants';
+import CardWithHeader from '@/components/CardWithHeader';
 import Spinner from '@/components/Spinner';
 import { switchChain } from '@/util';
+import { Tooltip } from 'react-tooltip';
 
 type FormData = {
   delegateAddress: string;
@@ -65,62 +68,70 @@ const Delegate: NextPage = () => {
       <Head>
         <title>Cross Chain Voting: Delegate</title>
       </Head>
-      <div className="flex justify-center align-center self-center h-full w-1/3">
+      <div className="flex justify-center align-center self-center h-full w-1/2">
         <div className="flex flex-col m-4 w-full gap-5">
-          <div className="flex flex-col self-center">
-            <h1 className="py-5 block text-xl">Delegate on {mounted && config.l2.chain.name}</h1>
-            <div className="flex w-full py-4 justify-between">
-              <div className="flex flex-col">
-                <div>Token Balance</div>
-                <div className="flex align-center p-4 gap-1">
-                  <Image
-                    height="32"
-                    width="32"
-                    src={config.l2.tokenLogo}
-                    alt={`${config.name}'s Governor token logo`}
-                  />
-                  <div className="self-center">{mounted && (l2.token?.formatted || 0)}</div>
-                  <div className="self-center">{mounted && (l2.token?.symbol || '---')}</div>
-                </div>
-              </div>
-              <div className="flex flex-col">
-                <div>Voting Power</div>
-                <div className="flex align-center p-4 gap-1">
-                  <Image
-                    height="32"
-                    width="32"
-                    src={config.l2.tokenLogo}
-                    alt={`${config.name}'s Governor token logo`}
-                  />
-                  <div className="self-center">{mounted && l2VotingWeightFormatted}</div>
-                  <div className="self-center">{mounted && (l2.token?.symbol || '---')}</div>
-                </div>
-              </div>
+          <CardWithHeader header={'Bridge tokens'} className="w-full">
+            <div className="flex items-center gap-1.5 text-gray-600 py-2 mb-2 ">
+              <InformationCircleIcon className="h-4" />
+              <p className="text-sm ">
+                {mounted && l2.token?.symbol} determines {config.name} voting power on{' '}
+                {config.l2.chain.name}.
+              </p>
             </div>
-            <div className="flex w-full py-4 justify-between">
+
+            <div className="flex flex-col gap-2 w-full  bg-gray-50 py-6 shadow-md px-5 rounded-lg">
+              <div className="flex justify-between">
+                <div className="flex flex-col">
+                  <div>Token Balance</div>
+                  <div className="flex align-center p-4 gap-1">
+                    <Image
+                      height="32"
+                      width="32"
+                      src={config.l2.tokenLogo}
+                      alt={`${config.name}'s Governor token logo`}
+                    />
+                    <div className="self-center">{mounted && (l2.token?.formatted || 0)}</div>
+                    <div className="self-center">{mounted && (l2.token?.symbol || '---')}</div>
+                  </div>
+                </div>
+                <div className="flex flex-col">
+                  <div>Voting Power</div>
+                  <div className="flex align-center p-4 gap-1">
+                    <Image
+                      height="32"
+                      width="32"
+                      src={config.l2.tokenLogo}
+                      alt={`${config.name}'s Governor token logo`}
+                    />
+                    <div className="self-center">{mounted && l2VotingWeightFormatted}</div>
+                    <div className="self-center">{mounted && (l2.token?.symbol || '---')}</div>
+                  </div>
+                </div>
+              </div>
               <div className="flex flex-col">
                 <div>Delegated To</div>
                 <div className="flex align-center p-4 gap-1">
                   <div className="self-center">
-                    {mounted && delegatee !== ZERO_ADDRESS ? delegatee : 'No one'}
+                    {mounted && delegatee !== ZERO_ADDRESS ? (
+                      <div className="flex items-start gap-1">
+                        {delegatee}{' '}
+                        <InformationCircleIcon id="delegate-address-information" className="h-4" />
+                      </div>
+                    ) : (
+                      'No one'
+                    )}
                   </div>
+                  <Tooltip
+                    anchorSelect="#delegate-address-information"
+                    content="Voting power for a given proposal is based on delegations at the time the proposal was created."
+                  />
                 </div>
               </div>
             </div>
-            <div className="flex flex-col max-w-lg self-center">
-              <div className="text-sm">
-                <p>
-                  {mounted && l2.token?.symbol} determines {config.name} voting power on{' '}
-                  {config.l2.chain.name}.
-                </p>
-                <p className="mt-2">
-                  <span className="font-bold">Note:</span> They must be delegated before a proposal
-                  has been proposed in order to be considered for that proposal.
-                </p>
-              </div>
+            <div className="flex flex-col max-w-lg self-center mt-2">
               <form className="py-3" onSubmit={onSubmit}>
                 <label className="block text-sm font-medium leading-6 text-gray-900">
-                  Delegate Address
+                  <strong>Delegate Address</strong>
                 </label>
                 <div className="relative mt-2 rounded-md shadow-sm">
                   <input
@@ -155,34 +166,34 @@ const Delegate: NextPage = () => {
                     {errors.delegateAddress.message}
                   </p>
                 )}
-                {mounted && chain?.id !== config.l2.chain.id ? (
-                  <button
-                    type="button"
-                    className="mt-5 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
-                    onClick={async () => {
-                      if (walletClient) switchChain(walletClient, config.l2.chain);
-                    }}
-                    disabled={walletIsLoading}
-                  >
-                    Switch network to {config.l2.chain.name}
-                  </button>
-                ) : (
-                  <button
-                    className="flex flex-row mt-5 items-center rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
-                    type="submit"
-                    disabled={Boolean(errors?.delegateAddress) || isLoading}
-                  >
-                    Delegate
-                    {isLoading && (
-                      <span className="ml-2">
-                        <Spinner />
-                      </span>
-                    )}
-                  </button>
-                )}
+                <div className="flex justify-center">
+                  {mounted && chain?.id !== config.l2.chain.id ? (
+                    <button
+                      type="button"
+                      className="mt-5 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+                      onClick={() => walletClient?.switchChain({ id: config.l2.chain.id })}
+                      disabled={walletIsLoading}
+                    >
+                      Switch network to {config.l2.chain.name}
+                    </button>
+                  ) : (
+                    <button
+                      className="flex flex-row mt-5 items-center rounded-md bg-indigo-600 px-8 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+                      type="submit"
+                      disabled={Boolean(errors?.delegateAddress) || isLoading}
+                    >
+                      Delegate
+                      {isLoading && (
+                        <span className="ml-2">
+                          <Spinner />
+                        </span>
+                      )}
+                    </button>
+                  )}
+                </div>
               </form>
             </div>
-          </div>
+          </CardWithHeader>
         </div>
       </div>
     </>

--- a/pages/[id]/delegate.tsx
+++ b/pages/[id]/delegate.tsx
@@ -68,7 +68,7 @@ const Delegate: NextPage = () => {
       <Head>
         <title>Cross Chain Voting: Delegate</title>
       </Head>
-      <div className="flex justify-center align-center self-center h-full w-1/2">
+      <div className="flex justify-center align-center self-center h-full max-w-lg">
         <div className="flex flex-col m-4 w-full gap-5">
           <CardWithHeader header={'Bridge tokens'} className="w-full">
             <div className="flex items-center gap-1.5 text-gray-600 py-2 mb-2 ">

--- a/pages/[id]/delegate.tsx
+++ b/pages/[id]/delegate.tsx
@@ -70,7 +70,7 @@ const Delegate: NextPage = () => {
       </Head>
       <div className="flex justify-center align-center self-center h-full max-w-lg">
         <div className="flex flex-col m-4 w-full gap-5">
-          <CardWithHeader header={'Bridge tokens'} className="w-full">
+          <CardWithHeader header={`Delegate on ${mounted && config.l2.chain.name}`} className="w-full">
             <div className="flex items-center gap-1.5 text-gray-600 py-2 mb-2 ">
               <InformationCircleIcon className="h-4" />
               <p className="text-sm ">

--- a/pages/[id]/delegate.tsx
+++ b/pages/[id]/delegate.tsx
@@ -70,7 +70,10 @@ const Delegate: NextPage = () => {
       </Head>
       <div className="flex justify-center align-center self-center h-full max-w-lg">
         <div className="flex flex-col m-4 w-full gap-5">
-          <CardWithHeader header={`Delegate on ${mounted && config.l2.chain.name}`} className="w-full">
+          <CardWithHeader
+            header={`Delegate on ${mounted && config.l2.chain.name}`}
+            className="w-full"
+          >
             <div className="flex items-center gap-1.5 text-gray-600 py-2 mb-2 ">
               <InformationCircleIcon className="h-4" />
               <p className="text-sm ">
@@ -171,7 +174,9 @@ const Delegate: NextPage = () => {
                     <button
                       type="button"
                       className="mt-5 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
-                      onClick={() => walletClient?.switchChain({ id: config.l2.chain.id })}
+                      onClick={async () => {
+                        if (walletClient) switchChain(walletClient, config.l2.chain);
+                      }}
                       disabled={walletIsLoading}
                     >
                       Switch network to {config.l2.chain.name}

--- a/pages/[id]/vote.tsx
+++ b/pages/[id]/vote.tsx
@@ -12,6 +12,7 @@ import ProposalRow from '@/components/ProposalRow';
 
 // proposal information
 //
+
 // 1. Name of the proposal
 // 2. Start date
 // 3. L2 voting end date

--- a/pages/[id]/vote.tsx
+++ b/pages/[id]/vote.tsx
@@ -12,7 +12,6 @@ import ProposalRow from '@/components/ProposalRow';
 
 // proposal information
 //
-
 // 1. Name of the proposal
 // 2. Start date
 // 3. L2 voting end date

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.4.2":
+  version: 1.5.0
+  resolution: "@floating-ui/core@npm:1.5.0"
+  dependencies:
+    "@floating-ui/utils": ^0.1.3
+  checksum: 54b4fe26b3c228746ac5589f97303abf158b80aa5f8b99027259decd68d1c2030c4c637648ebd33dfe78a4212699453bc2bd7537fd5a594d3bd3e63d362f666f
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.0.0":
+  version: 1.5.3
+  resolution: "@floating-ui/dom@npm:1.5.3"
+  dependencies:
+    "@floating-ui/core": ^1.4.2
+    "@floating-ui/utils": ^0.1.3
+  checksum: 00053742064aac70957f0bd5c1542caafb3bfe9716588bfe1d409fef72a67ed5e60450d08eb492a77f78c22ed1ce4f7955873cc72bf9f9caf2b0f43ae3561c21
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.1.3":
+  version: 0.1.6
+  resolution: "@floating-ui/utils@npm:0.1.6"
+  checksum: b34d4b5470869727f52e312e08272edef985ba5a450a76de0917ba0a9c6f5df2bdbeb99448e2c60f39b177fb8981c772ff1831424e75123471a27ebd5b52c1eb
+  languageName: node
+  linkType: hard
+
 "@headlessui/react@npm:^1.7.17":
   version: 1.7.17
   resolution: "@headlessui/react@npm:1.7.17"
@@ -2341,6 +2367,13 @@ __metadata:
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
   checksum: c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
+  languageName: node
+  linkType: hard
+
+"classnames@npm:^2.3.0":
+  version: 2.3.2
+  resolution: "classnames@npm:2.3.2"
+  checksum: 2c62199789618d95545c872787137262e741f9db13328e216b093eea91c85ef2bfb152c1f9e63027204e2559a006a92eb74147d46c800a9f96297ae1d9f96f4e
   languageName: node
   linkType: hard
 
@@ -5512,6 +5545,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-tooltip@npm:^5.23.0":
+  version: 5.23.0
+  resolution: "react-tooltip@npm:5.23.0"
+  dependencies:
+    "@floating-ui/dom": ^1.0.0
+    classnames: ^2.3.0
+  peerDependencies:
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
+  checksum: 03db3e7c1ccade26d95ec2418c0374f510e3ae7620be871900e02f5f749d539df688035867c89fcd480c5636d3048b6d580554bd291f708371d057aac54894a4
+  languageName: node
+  linkType: hard
+
 "react@npm:^18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
@@ -6872,6 +6918,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-hook-form: ^7.47.0
+    react-tooltip: ^5.23.0
     swr: ^2.2.4
     tailwindcss: ^3.3.3
     typescript: ^5.0.4


### PR DESCRIPTION
#### Description


* Make the delegate page match more with the bridge page, such as:
  * Put the same border around it
  * Put the middle section showing voting power in the same grey box as the network/token on the bridge page
  * Put the button in the middle
* Move  the message “POOL.fv determines PoolTogether voting power on Optimism Goerli.” above the balances
* The message “Note: They must be delegated before a proposal has been proposed in order to be considered for that proposal.” is moved into a tooltip with an “(i)” next to the address delegated to. The copy was updated to  “Voting power for a given proposal is based on delegations at the time the proposal was created.”
* Instead of a grey box, we now use the same border and white background when the proposal is not yet bridged to L2, and we changed the copy to say “Proposal is not yet bridged to L2”