### PR TITLE
Change L2 proposal status after bridge

### DIFF
--- a/hooks/useProposals.ts
+++ b/hooks/useProposals.ts
@@ -222,6 +222,7 @@ const useL2ProposalsState = (l2Proposals?: { proposalId: string; startBlock: str
     isLoading,
     error,
   } = useContractReads({
+    watch: true,
     contracts: l2Proposals?.map((proposal) => {
       return {
         address: l2.voteAggregator,


### PR DESCRIPTION
#### Description

- Before a proposal is bridged the status of the proposal is "closed". If we don't watch this will not change after the proposal is bridged.